### PR TITLE
Fix issues with loading Vue.

### DIFF
--- a/src/vc_visual_verifier/templates/visual_verifier.html
+++ b/src/vc_visual_verifier/templates/visual_verifier.html
@@ -16,7 +16,7 @@
     <link
       type="text/css"
       rel="stylesheet"
-      href="//unpkg.com/bootstrap-vue@2.15.0/dist/bootstrap-vue.min.css"
+      href="//unpkg.com/bootstrap-vue@2.21.2/dist/bootstrap-vue.min.css"
     />
 
     <!-- Load polyfills to support older browsers -->
@@ -26,11 +26,11 @@
     ></script>
 
     <!-- Load Vue followed by BootstrapVue -->
-    <script src="//unpkg.com/vue@latest/dist/vue.min.js"></script>
-    <script src="//unpkg.com/bootstrap-vue@2.15.0/dist/bootstrap-vue.min.js"></script>
+    <script src="//unpkg.com/vue@2.6.14/dist/vue.min.js"></script>
+    <script src="//unpkg.com/bootstrap-vue@2.21.2/dist/bootstrap-vue.min.js"></script>
     <script src="//unpkg.com/axios/dist/axios.min.js"></script>
     <!-- Load the following for BootstrapVueIcons support -->
-    <script src="//unpkg.com/bootstrap-vue@2.15.0/dist/bootstrap-vue-icons.min.js"></script>
+    <script src="//unpkg.com/bootstrap-vue@2.21.2/dist/bootstrap-vue-icons.min.js"></script>
 
     <title>VC Visual Verifier</title>
   </head>


### PR DESCRIPTION
- A new version of Vue was released which changes the file package naming.
- Pin the version of Vue to a version known to work for our app until we have time to upgrade to Vue 3.
- This is a break fix.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>